### PR TITLE
Deploy artifacts to Sonatype OSS for syncing to Maven Central; change gr...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.springframework.social</groupId>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+	<groupId>uk.co.michaellavelle</groupId>
 	<artifactId>spring-social-lastfm</artifactId>
 	<packaging>jar</packaging>
 	<version>1.0.2-SNAPSHOT</version>
 	<name>Spring Social LastFm</name>
+    <scm>
+        <url>scm:git:git@github.com:michaellavelle/spring-social-lastfm.git</url>
+        <connection>scm:git:git@github.com:michaellavelle/spring-social-lastfm.git</connection>
+        <developerConnection>scm:git:git@github.com:michaellavelle/spring-social-lastfm.git</developerConnection>
+    </scm>
 	<properties>
 			<org.springframework.social.version>1.0.2.RELEASE</org.springframework.social.version>
 			<org.springframework.version>3.1.1.RELEASE</org.springframework.version>
 	</properties>
-	<distributionManagement>
-	 	<repository>
-		<id>repo</id>
-			<url>https://github.com/OpenSourceAgility/opensourceagility-mvn-repo/raw/master/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>snapshot-repo</id>
-			<url>https://github.com/OpenSourceAgility/opensourceagility-mvn-repo/raw/master/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
 	<dependencies>
 	    <dependency>
   <groupId>org.springframework.social</groupId>


### PR DESCRIPTION
...oupId according to Sonatype policy

Publishing this artifact to Maven Central would increase its accessibility. Sonatype OSS provides free Maven hosting and syncing to Maven Central for open source projects. This pull request configures spring-social-lastfm for deployment to Sonatype OSS. Next steps here: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide

Note that I had to change the groupId in accordance with Sonatype policy. Other than that it should be a simple process.
